### PR TITLE
ASUS GPU Name Problem (Replaced colons with underlines)

### DIFF
--- a/icue2mqtt/Models/MqttIcueDeviceList.cs
+++ b/icue2mqtt/Models/MqttIcueDeviceList.cs
@@ -47,7 +47,7 @@ namespace icue2mqtt.Models
             {
                 return null;
             }
-            string entityId = icueDevice.CorsairDevice.Model.Replace(" ", "_");
+            string entityId = icueDevice.CorsairDevice.Model.Replace(" ", "_").Replace(":", "_");
             if (suffixNumber > 0)
             {
                 entityId += "_" + suffixNumber;


### PR DESCRIPTION
I noticed it trying to create a MQTT Topic with a Colon (":") which is apparently not a valid symbol for MQTT.
If you have the ASUS "AURA" integration in your iCUE software it adds RGB control for your ASUS GPU. This GPU is then named "ASUS GPU: VGA 1" which has a colon in it.

TLDR: This replaces the colon (":") symbol with an underline ("_")